### PR TITLE
checkbox在表格循环中，如果字典里不存在重复出现整个数组

### DIFF
--- a/packages/utils/util.js
+++ b/packages/utils/util.js
@@ -36,7 +36,7 @@ export const findByvalue = (dic, value) => {
       if (index != -1) {
         result.push(dic[index].label);
       } else {
-        result.push(value);
+        result.push(ele);
       }
     });
     result = result.toString();


### PR DESCRIPTION
重现步骤：
字典数据：[{label:'呵呵',value:1},{label:'嘻嘻',value:2}]
column 数据[1,2,3,4,5]
期望内容： 呵呵，嘻嘻，3，4，5
实际内容：呵呵，嘻嘻，12345，12345
