### PR TITLE
fix: crud searchOrder sort

### DIFF
--- a/packages/element-ui/crud/header-search.vue
+++ b/packages/element-ui/crud/header-search.vue
@@ -134,7 +134,7 @@ export default cteate({
         let column = [];
         let count = 0;
         //根据order排序
-        list = list.sort((a, b) => (b.searchOrder || 0) - (a.searchOrder || 0))
+        list = list.filter(item => item.searchOrder != undefined).sort((a, b) => (a.searchOrder || 0) - (b.searchOrder || 0)).concat(list.filter(item => item.searchOrder === undefined))
         list.forEach(ele => {
           if (ele.search) {
             let isCount = count < this.searchIndex


### PR DESCRIPTION
根据gitee issue [I34NT8](https://gitee.com/smallweigit/avue/issues/I34NT8)
如实际column里的searchOrder为[8,6,3,4,,,1,,]，其中空值为没有searchOrder的项，比较通用排序应该为[1,3,4,6,8,,,,]
没有searchOrder属性的项后置到排序后的项，这样维护已排序的search会比较方便。