### PR TITLE
fix: 修复 upload/index.vue 控件，2.9.0版本不能查看图片的BUG

### DIFF
--- a/packages/element-ui/upload/index.vue
+++ b/packages/element-ui/upload/index.vue
@@ -393,7 +393,7 @@ export default create({
       const callback = () => {
         let url = file.url
         let list = this.fileList.map(ele => Object.assign(ele, {
-          type: this.typeList.video.test(ele.url) ? 'video' : ''
+          type: typeList.video.test(ele.url) ? 'video' : ''
         }))
         let index = this.fileList.findIndex(ele => {
           return ele.url === url;


### PR DESCRIPTION
fix: 修复 upload/index.vue 控件，2.9.0版本不能查看图片的BUG

没有测试吧，官方在线示例也有这问题。