### PR TITLE
解决crud组件height设置为auto,全屏后高度不重新计算

### DIFF
--- a/packages/element-ui/crud/index.vue
+++ b/packages/element-ui/crud/index.vue
@@ -441,7 +441,7 @@ export default create({
           if (!tableRef) return
           const tableStyle = tableRef.$el;
           const pageStyle = tablePageRef.$el.offsetHeight || 20;
-          this.tableHeight = config.clientHeight - tableStyle.offsetTop - pageStyle - this.calcHeight
+          this.tableHeight = document.documentElement.clientHeight - tableStyle.offsetTop - pageStyle - this.calcHeight
         })
       } else {
         this.tableHeight = this.tableOption.height;


### PR DESCRIPTION
主要原因是因为高度需要重新获取document.documentElement.clientHeight 而不是拿config里面的变量